### PR TITLE
Migrate to flat config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '18', '20', '22']
+        node: ['18', '20', '22']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -14,36 +14,29 @@ npm i --save-dev eslint eslint-plugin-icedfrisby
 
 ## Usage
 
-Add `icedfrisby` to the plugins section of your `.eslintrc` configuration file.
+As of eslint-plugin-icedfrisby 0.2.0 this plugin is compatible with ESLint>=8.21.0 only and must be configured using flat config format.
 
-```json
-{
-    "plugins": [
-        "icedfrisby"
-    ]
-}
-```
+Example `.eslint.config.js` file:
 
-Then configure the rules you want to use under the rules section. e.g:
+```js
+const icedfrisby = require("eslint-plugin-icedfrisby");
 
-```json
-{
-    "rules": {
-        "icedfrisby/no-exclusive-tests:": ["error"]
-    }
-}
-```
+module.exports = [
+  // This plugin exports a recommended config
+  icedfrisby.configs.recommended,
 
-## Configs
+  {
+    // Add icedfrisby to the plugins declaration
+    plugins: {
+      icedfrisby,
+    },
 
-This plugin exports a recommended config:
-
-```json
-{
-    "extends": [
-        "plugin:icedfrisby/recommended"
-    ]
-}
+    // Optionally customise or configure rules
+    rules: {
+      "icedfrisby/no-skipped-tests": ["error"]
+    },
+  },
+];
 ```
 
 ## Rules

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,15 +2,22 @@
 
 const requireIndex = require("requireindex");
 
-module.exports = {
+const plugin = {
+  configs: {},
   rules: requireIndex(__dirname + "/rules"),
-  configs: {
-    recommended: {
-      plugins: ["icedfrisby"],
-      rules: {
-        "icedfrisby/no-exclusive-tests": "error",
-        "icedfrisby/no-skipped-tests": "warn",
-      },
+  processors: {},
+};
+
+Object.assign(plugin.configs, {
+  recommended: {
+    plugins: {
+      icedfrisby: plugin,
+    },
+    rules: {
+      "icedfrisby/no-exclusive-tests": "error",
+      "icedfrisby/no-skipped-tests": "warn",
     },
   },
-};
+});
+
+module.exports = plugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=7"
+        "eslint": ">=8.21.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "^3.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.21.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7"
+    "eslint": ">=8.21.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "^3.0.0"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+    "node": ">= 18.0.0"
   },
   "peerDependencies": {
     "eslint": ">=8.21.0"


### PR DESCRIPTION
This PR migrates the plugin to be compatible with flat config.

It seems like in order to have compatibility with both the legacy RC format and flat format you have to export 2 versions of the plugin. I think for this plugin (which basically has one consumer) I don't really care about this. When I merge this I will put out a v0.2.0 that is only compatible with flat config and we can stay on v0.1.0 until such time as we want to migrate.

I've tested the plugin against both ESLint 8 and ESLint 9, although this repo will need to keep using 8.x for linting at the moment unless I drop eslint-doc-generator (refs https://github.com/bmish/eslint-doc-generator/issues/526 )

Dropping node <18 will unblock upgrading to mocha 11